### PR TITLE
Add active scan for DALI input devices

### DIFF
--- a/config/custom_components/foxtron_dali/config_flow.py
+++ b/config/custom_components/foxtron_dali/config_flow.py
@@ -134,6 +134,9 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
         """Handle the button discovery and adoption step."""
         driver: FoxtronDaliDriver = self.hass.data[DOMAIN][self.config_entry.entry_id]
 
+        # Actively scan the bus for input devices before showing the form
+        await driver.scan_for_input_devices()
+
         # This block runs when the user clicks SUBMIT on the form
         if user_input is not None:
             # Get the list of buttons already in the config

--- a/config/custom_components/foxtron_dali/event.py
+++ b/config/custom_components/foxtron_dali/event.py
@@ -74,7 +74,7 @@ class DaliButton(EventEntity):
         try:
             while self.hass.is_running:
                 event = await self._driver.get_event()
-                if not isinstance(event, DaliInputNotificationEvent) or event.address != self._address:
+                if not isinstance(event, DaliInputNotificationEvent):
                     continue
 
                 event_type = EVENT_CODE_NAMES.get(


### PR DESCRIPTION
## Summary
- add DALI `scan_for_input_devices` to proactively find button modules
- invoke input device scan during config flow setup
- allow event entity to process all DALI input notifications

## Testing
- `pytest`
- `python -m py_compile config/custom_components/foxtron_dali/driver.py config/custom_components/foxtron_dali/config_flow.py config/custom_components/foxtron_dali/event.py`


------
https://chatgpt.com/codex/tasks/task_e_6898ebe964e48323bbe887464835fa76