### PR TITLE
Clean up Foxtron DALI services when last config entry unloads

### DIFF
--- a/config/custom_components/foxtron_dali/__init__.py
+++ b/config/custom_components/foxtron_dali/__init__.py
@@ -100,6 +100,17 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         driver: FoxtronDaliDriver = hass.data[DOMAIN].pop(entry.entry_id)
         await driver.disconnect()
 
+        # If this was the last configured entry, clean up the global services
+        if not hass.data[DOMAIN]:
+            hass.data.pop(DOMAIN)
+            for service in (
+                "broadcast_on",
+                "broadcast_off",
+                "set_fade_time",
+                "scan_for_lights",
+            ):
+                hass.services.async_remove(DOMAIN, service)
+
     return unload_ok
 
 


### PR DESCRIPTION
## Summary
- Remove global Foxtron DALI services when the final config entry is unloaded

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898f840af948323b5340e4fc17f28da