### PR TITLE
Handle DALI button instances separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Once a new button is detected, a persistent notification will appear in your Hom
 To add the button:
 1.  Go to **Settings > Devices & Services**.
 2.  Find the Foxtron DALI integration card and click **CONFIGURE**.
-3.  A list of newly discovered button addresses will be shown.
+3.  A list of newly discovered button instances (address and instance) will be shown.
 4.  Select the button(s) you wish to add and click **Submit**.
 
 **3. Using the Button in Automations**
@@ -90,9 +90,11 @@ automation:
       - platform: event
         event_type: dali_event
         event_data:
-          # This is the unique_id of the integration entry plus the button address.
-          # You can find the correct unique_id in the developer tools under events.
-          unique_id: "YOUR_CONFIG_ENTRY_ID_5" 
+          # Unique ID of the integration entry. Use address and raw_instance to
+          # target a specific button.
+          unique_id: "YOUR_CONFIG_ENTRY_ID"
+          address: 56
+          raw_instance: 128
           # This is the specific button action you want to react to.
           event_type: "short_press"
     action:

--- a/custom_components/foxtron_dali/config_flow.py
+++ b/custom_components/foxtron_dali/config_flow.py
@@ -141,25 +141,33 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
         # This block runs when the user clicks SUBMIT on the form
         if user_input is not None:
             # Get the list of buttons already in the config
-            existing_buttons = self.config_entry.options.get("buttons", [])
+            existing_buttons = []
+            for btn in self.config_entry.options.get("buttons", []):
+                if isinstance(btn, (list, tuple)) and len(btn) == 2:
+                    existing_buttons.append((int(btn[0]), int(btn[1])))
+                else:
+                    existing_buttons.append((int(btn), 0))
 
             # Get the list of newly selected buttons from the form
-            # The multi-select returns a list of strings (the keys), so we convert to int
-            selected_buttons = [int(addr) for addr in user_input.get("buttons", [])]
+            # The multi-select returns a list of strings ("addr-raw"), so parse them
+            selected_buttons = [
+                tuple(int(part) for part in addr.split("-"))
+                for addr in user_input.get("buttons", [])
+            ]
 
             # Combine the old and new lists and remove any duplicates
-            all_buttons = sorted(list(set(existing_buttons + selected_buttons)))
+            all_buttons = sorted(set(existing_buttons + selected_buttons))
 
             # Tell the driver that these buttons are now known
-            for button_addr in selected_buttons:
-                driver.add_known_button(button_addr)
+            for button_addr, raw_instance in selected_buttons:
+                driver.add_known_button(button_addr, raw_instance)
 
             # Clear the driver's cache of newly discovered buttons
             driver.clear_newly_discovered_buttons()
 
             # Create a new options dictionary with the updated button list
             new_options = self.config_entry.options.copy()
-            new_options["buttons"] = all_buttons
+            new_options["buttons"] = [list(btn) for btn in all_buttons]
 
             # Save the updated options to the config entry
             return self.async_create_entry(title="", data=new_options)
@@ -168,9 +176,10 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
         # Get the list of buttons the driver has seen but are not yet configured
         newly_discovered = driver.get_newly_discovered_buttons()
 
-        # Format them for the multi-select list: { "address_as_string": "Button Name" }
+        # Format them for the multi-select list: { "addr-raw": "Button Name" }
         self.discovered_buttons = {
-            str(addr): f"DALI Button {addr}" for addr in newly_discovered
+            f"{addr}-{raw}": f"DALI Button {addr} (inst 0x{raw:02X})"
+            for addr, raw in newly_discovered
         }
 
         # If no new buttons have been seen, show an informational message.

--- a/custom_components/foxtron_dali/event.py
+++ b/custom_components/foxtron_dali/event.py
@@ -95,9 +95,10 @@ class DaliButton(EventEntity):
             "address": event.address,
             "address_type": event.address_type,
             "instance_number": event.instance_number,
+            "raw_instance": event.raw_instance,
         }
 
-        key = f"{event.address_type}:{event.address}:{event.instance_number}"
+        key = f"{event.address_type}:{event.address}:{event.raw_instance}"
         state = self._button_states.setdefault(key, _ButtonState())
         state.last_event_data = data
 


### PR DESCRIPTION
## Summary
- Track DALI button instances using address and raw instance byte
- Surface raw instance in button events and discovery workflow
- Update docs and examples for instance-aware button handling

## Testing
- `python -m py_compile custom_components/foxtron_dali/config_flow.py custom_components/foxtron_dali/driver.py custom_components/foxtron_dali/event.py`


------
https://chatgpt.com/codex/tasks/task_e_689ad92a6a34832389d645fe45546c3a