### PR TITLE
Add tests for DaliButton event handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,13 @@ The `event_type` in the trigger can be any of the following standard DALI-2 even
 *   `long_press_start`
 *   `long_press_repeat`
 *   `long_press_stop`
-*   `button_stuck`
-*   `button_free`
+
+Foxtron DALI4SW devices are configured to send only the `button_pressed` and
+`button_released` notifications on the bus. The integration reconstructs all
+other button events locally based on timing. These thresholds (long press
+delay, repeat interval, and multi-press window) can be adjusted in the
+integration's configuration options. Any other button events from the bus are
+ignored.
 
 ## Services
 

--- a/custom_components/foxtron_dali/config_flow.py
+++ b/custom_components/foxtron_dali/config_flow.py
@@ -12,6 +12,11 @@ from homeassistant.helpers import config_validation as cv
 
 from .const import DOMAIN
 from .driver import FoxtronDaliDriver, format_button_id, parse_button_id
+from .event import (
+    DEFAULT_LONG_PRESS_THRESHOLD,
+    DEFAULT_LONG_PRESS_REPEAT,
+    DEFAULT_MULTI_PRESS_WINDOW,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -89,7 +94,12 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
         # The user sees this menu first when they click "CONFIGURE"
         return self.async_show_menu(
             step_id="init",
-            menu_options=["discover_buttons", "set_fade_time", "upload_config"],
+            menu_options=[
+                "discover_buttons",
+                "set_fade_time",
+                "set_event_timing",
+                "upload_config",
+            ],
         )
 
     async def async_step_upload_config(self, user_input: Optional[Dict[str, Any]] = None):
@@ -126,6 +136,43 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                 }
             ),
             errors=errors
+        )
+
+    async def async_step_set_event_timing(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ):
+        """Handle configuration of button event timing."""
+        if user_input is not None:
+            new_options = self.config_entry.options.copy()
+            new_options["long_press_threshold"] = user_input["long_press_threshold"]
+            new_options["long_press_repeat"] = user_input["long_press_repeat"]
+            new_options["multi_press_window"] = user_input["multi_press_window"]
+            return self.async_create_entry(title="", data=new_options)
+
+        return self.async_show_form(
+            step_id="set_event_timing",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        "long_press_threshold",
+                        default=self.config_entry.options.get(
+                            "long_press_threshold", DEFAULT_LONG_PRESS_THRESHOLD
+                        ),
+                    ): vol.Coerce(float),
+                    vol.Required(
+                        "long_press_repeat",
+                        default=self.config_entry.options.get(
+                            "long_press_repeat", DEFAULT_LONG_PRESS_REPEAT
+                        ),
+                    ): vol.Coerce(float),
+                    vol.Required(
+                        "multi_press_window",
+                        default=self.config_entry.options.get(
+                            "multi_press_window", DEFAULT_MULTI_PRESS_WINDOW
+                        ),
+                    ): vol.Coerce(float),
+                }
+            ),
         )
 
     async def async_step_discover_buttons(

--- a/custom_components/foxtron_dali/driver.py
+++ b/custom_components/foxtron_dali/driver.py
@@ -689,8 +689,16 @@ class FoxtronDaliDriver:
         if event:
             # Log the received event for debugging purposes
             _LOGGER.debug("Received event: %r", event)
-            # If a new button is discovered, add it to the discovery set
             if isinstance(event, DaliInputNotificationEvent):
+                if event.event_code not in (
+                    EVENT_BUTTON_PRESSED,
+                    EVENT_BUTTON_RELEASED,
+                ):
+                    _LOGGER.debug(
+                        "Ignoring input notification %s", 
+                        EVENT_CODE_NAMES.get(event.event_code, f"0x{event.event_code:02X}")
+                    )
+                    return
                 if (
                     event.address_type == "Short"
                     and event.address is not None

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,232 @@
+import asyncio
+import os
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import importlib
+import pytest
+import pytest_asyncio
+
+
+# ---------------------------------------------------------------------------
+# Minimal stubs for the required Home Assistant classes. These stubs allow the
+# tests to run in environments where the ``homeassistant`` package is not
+# available. Only the attributes and methods accessed by the integration are
+# implemented.
+# ---------------------------------------------------------------------------
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub package structure for custom_components to avoid executing integration
+# __init__ modules during import.
+custom_components_pkg = ModuleType("custom_components")
+custom_components_pkg.__path__ = [os.path.abspath("custom_components")]
+foxtron_pkg = ModuleType("custom_components.foxtron_dali")
+foxtron_pkg.__path__ = [os.path.abspath("custom_components/foxtron_dali")]
+sys.modules.setdefault("custom_components", custom_components_pkg)
+sys.modules.setdefault("custom_components.foxtron_dali", foxtron_pkg)
+
+ha = ModuleType("homeassistant")
+sys_modules = {
+    "homeassistant": ha,
+    "homeassistant.components": ModuleType("homeassistant.components"),
+    "homeassistant.components.event": ModuleType(
+        "homeassistant.components.event"
+    ),
+    "homeassistant.config_entries": ModuleType(
+        "homeassistant.config_entries"
+    ),
+    "homeassistant.core": ModuleType("homeassistant.core"),
+    "homeassistant.helpers": ModuleType("homeassistant.helpers"),
+    "homeassistant.helpers.entity_platform": ModuleType(
+        "homeassistant.helpers.entity_platform"
+    ),
+}
+
+
+class EventEntity:
+    """Very small subset of HA's EventEntity used in tests."""
+
+    async def async_added_to_hass(self):
+        return None
+
+    async def async_will_remove_from_hass(self):
+        return None
+
+    def _trigger_event(self, event_type: str, event_attributes: dict | None = None):
+        return None
+
+
+class HomeAssistant:
+    """Minimal HomeAssistant implementation."""
+
+    def __init__(self):
+        self.loop = asyncio.get_event_loop()
+
+    def async_create_task(self, coro):
+        return self.loop.create_task(coro)
+
+
+class ConfigEntry:
+    def __init__(self, entry_id: str, data: dict):
+        self.entry_id = entry_id
+        self.data = data
+
+
+class AddEntitiesCallback:
+    pass
+
+
+sys_modules["homeassistant.components.event"].EventEntity = EventEntity
+sys_modules["homeassistant.core"].HomeAssistant = HomeAssistant
+sys_modules["homeassistant.config_entries"].ConfigEntry = ConfigEntry
+sys_modules["homeassistant.helpers.entity_platform"].AddEntitiesCallback = (
+    AddEntitiesCallback
+)
+
+# Register stub modules
+import sys
+
+for name, module in sys_modules.items():
+    sys.modules.setdefault(name, module)
+
+
+event_module = importlib.import_module("custom_components.foxtron_dali.event")
+DaliButton = event_module.DaliButton
+driver_module = importlib.import_module("custom_components.foxtron_dali.driver")
+DaliInputNotificationEvent = driver_module.DaliInputNotificationEvent
+EVENT_BUTTON_PRESSED = driver_module.EVENT_BUTTON_PRESSED
+EVENT_BUTTON_RELEASED = driver_module.EVENT_BUTTON_RELEASED
+EVENT_LONG_PRESS_START = driver_module.EVENT_LONG_PRESS_START
+
+
+class MockDriver:
+    """Minimal driver used for testing DaliButton."""
+
+    def add_event_listener(self, callback):
+        self._callback = callback
+
+        def _unsub():
+            self._callback = None
+
+        return _unsub
+
+    async def emit(self, event):
+        if self._callback:
+            result = self._callback(event)
+            if asyncio.iscoroutine(result):
+                await result
+
+
+def _make_event(code: int) -> DaliInputNotificationEvent:
+    """Helper to create a DaliInputNotificationEvent with a fixed address."""
+    return DaliInputNotificationEvent(bytes([0x02, 0x04, code]))
+
+
+@pytest_asyncio.fixture
+async def button():
+    """Provide a DaliButton instance ready for testing."""
+    hass = HomeAssistant()
+    entry = MagicMock()
+    entry.entry_id = "entry"
+    entry.data = {"host": "test"}
+    entry.options = {}
+    driver = MockDriver()
+    button = DaliButton(entry, driver)
+    button.hass = hass
+    await button.async_added_to_hass()
+    yield button
+    await button.async_will_remove_from_hass()
+
+
+@pytest.mark.asyncio
+async def test_button_pressed_and_short_press(button, monkeypatch):
+    events = []
+
+    def capture(event_type, data):
+        events.append((event_type, data))
+
+    monkeypatch.setattr(button, "_trigger_event", capture)
+    button._multi_press_window = 0.01
+
+    await button._handle_event(_make_event(EVENT_BUTTON_PRESSED))
+    await button._handle_event(_make_event(EVENT_BUTTON_RELEASED))
+    await asyncio.sleep(0.02)
+
+    assert events[0] == (
+        "button_pressed",
+        {
+            "button_id": "1-1",
+            "address": 1,
+            "address_type": "Short",
+            "instance_number": 1,
+        },
+    )
+    assert events[1][0] == "button_released"
+    assert events[-1][0] == "short_press"
+
+
+@pytest.mark.asyncio
+async def test_double_and_triple_press(button, monkeypatch):
+    events = []
+
+    def capture(event_type, data):
+        events.append(event_type)
+
+    monkeypatch.setattr(button, "_trigger_event", capture)
+    button._multi_press_window = 0.01
+
+    # Double press
+    await button._handle_event(_make_event(EVENT_BUTTON_PRESSED))
+    await button._handle_event(_make_event(EVENT_BUTTON_RELEASED))
+    await button._handle_event(_make_event(EVENT_BUTTON_PRESSED))
+    await button._handle_event(_make_event(EVENT_BUTTON_RELEASED))
+    await asyncio.sleep(0.02)
+    assert events[-1] == "double_press"
+
+    events.clear()
+
+    # Triple press
+    await button._handle_event(_make_event(EVENT_BUTTON_PRESSED))
+    await button._handle_event(_make_event(EVENT_BUTTON_RELEASED))
+    await button._handle_event(_make_event(EVENT_BUTTON_PRESSED))
+    await button._handle_event(_make_event(EVENT_BUTTON_RELEASED))
+    await button._handle_event(_make_event(EVENT_BUTTON_PRESSED))
+    await button._handle_event(_make_event(EVENT_BUTTON_RELEASED))
+    await asyncio.sleep(0.02)
+    assert events[-1] == "triple_press"
+
+
+@pytest.mark.asyncio
+async def test_long_press_sequence(button, monkeypatch):
+    events = []
+
+    def capture(event_type, data):
+        events.append(event_type)
+
+    monkeypatch.setattr(button, "_trigger_event", capture)
+    button._long_press_threshold = 0.01
+    button._long_press_repeat = 0.01
+
+    await button._handle_event(_make_event(EVENT_BUTTON_PRESSED))
+    await asyncio.sleep(0.015)
+    await asyncio.sleep(0.015)
+    await button._handle_event(_make_event(EVENT_BUTTON_RELEASED))
+
+    assert events[0] == "button_pressed"
+    assert "long_press_start" in events
+    assert "long_press_repeat" in events
+    assert events[-1] == "long_press_stop"
+
+
+@pytest.mark.asyncio
+async def test_ignores_other_events(button, monkeypatch):
+    events = []
+
+    def capture(event_type, data):
+        events.append(event_type)
+
+    monkeypatch.setattr(button, "_trigger_event", capture)
+
+    await button._handle_event(_make_event(EVENT_LONG_PRESS_START))
+    assert events == []


### PR DESCRIPTION
## Summary
- ignore non-press DALI input notifications from the driver
- reconstruct button events in `DaliButton` with configurable timing options
- document button event reconstruction and update tests

## Testing
- `pip install pytest-asyncio -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c40b264688323ac9ed8c5cdb71981