### PR TITLE
Connect driver in background to register light services early

### DIFF
--- a/custom_components/foxtron_dali/driver.py
+++ b/custom_components/foxtron_dali/driver.py
@@ -548,6 +548,9 @@ class FoxtronDaliDriver:
         # Cache for results of bus scanning to avoid repeated full scans
         self._scan_cache: Optional[List[int]] = None
 
+        # Task created by the integration to establish the initial connection
+        self.connect_task: asyncio.Task | None = None
+
     async def connect(self):
         """Connects to the gateway."""
         await self._connection.connect()

--- a/custom_components/foxtron_dali/light.py
+++ b/custom_components/foxtron_dali/light.py
@@ -52,6 +52,11 @@ async def async_setup_entry(
 
     async def _scan_and_add() -> None:
         """Scan the bus and add discovered lights."""
+        connect_task = getattr(driver, "connect_task", None)
+        if connect_task:
+            await connect_task
+        else:
+            await driver.connect()
         discovered_addresses = await driver.scan_for_devices()
         updated_config = _generate_unique_id(light_config, discovered_addresses)
         lights = [


### PR DESCRIPTION
## Summary
- start DALI driver connection in background so light domain services are registered immediately
- wait for driver connection before scanning for lights
- cancel pending connection when unloading configuration

## Testing
- `pre-commit run --files custom_components/foxtron_dali/__init__.py custom_components/foxtron_dali/light.py custom_components/foxtron_dali/driver.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c6ff8fe0c83239252497ea6042ca4