### PR TITLE
Refactor config flow for latest Home Assistant

### DIFF
--- a/custom_components/foxtron_dali/config_flow.py
+++ b/custom_components/foxtron_dali/config_flow.py
@@ -9,6 +9,8 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 
+
+
 from .const import DOMAIN
 from .driver import FoxtronDaliDriver, format_button_id, parse_button_id
 from .event import (
@@ -20,11 +22,10 @@ from .event import (
 _LOGGER = logging.getLogger(__name__)
 
 
-class FoxtronDaliConfigFlow(config_entries.ConfigFlow):
+class FoxtronDaliConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Foxtron DALI."""
 
     VERSION = 1
-    domain = DOMAIN
 
     @staticmethod
     @callback

--- a/custom_components/foxtron_dali/config_flow.py
+++ b/custom_components/foxtron_dali/config_flow.py
@@ -21,9 +21,8 @@ from .event import (
 _LOGGER = logging.getLogger(__name__)
 
 
-class FoxtronDaliConfigFlow(  # type: ignore[misc, call-arg]
-    config_entries.ConfigFlow, domain=DOMAIN
-):
+@config_entries.HANDLERS.register(DOMAIN)
+class FoxtronDaliConfigFlow(config_entries.ConfigFlow):
     """Handle a config flow for Foxtron DALI."""
 
     VERSION = 1

--- a/custom_components/foxtron_dali/config_flow.py
+++ b/custom_components/foxtron_dali/config_flow.py
@@ -10,7 +10,6 @@ from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 
 
-
 from .const import DOMAIN
 from .driver import FoxtronDaliDriver, format_button_id, parse_button_id
 from .event import (
@@ -22,7 +21,9 @@ from .event import (
 _LOGGER = logging.getLogger(__name__)
 
 
-class FoxtronDaliConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class FoxtronDaliConfigFlow(  # type: ignore[misc, call-arg]
+    config_entries.ConfigFlow, domain=DOMAIN
+):
     """Handle a config flow for Foxtron DALI."""
 
     VERSION = 1


### PR DESCRIPTION
## Summary
- use new domain-based ConfigFlow declaration
- simplify options flow to rely on OptionsFlowWithReload

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ca73ff9b48323b8c87bff4aca57d0