### PR TITLE
Add backup light configuration option

### DIFF
--- a/custom_components/foxtron_dali/config_flow.py
+++ b/custom_components/foxtron_dali/config_flow.py
@@ -100,6 +100,7 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                 "set_fade_time",
                 "set_event_timing",
                 "upload_config",
+                "backup_config",
             ],
         )
 
@@ -142,6 +143,43 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                     vol.Required("file_path"): str,
                 }
             ),
+            errors=errors,
+        )
+
+    async def async_step_backup_config(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ):
+        """Handle backing up the light configuration to a file."""
+        errors = {}
+        if user_input is not None:
+            file_path = user_input["file_path"]
+            light_config = self.config_entry.options.get("light_config")
+            if not light_config:
+                errors["base"] = "no_config"
+            else:
+                try:
+                    with open(file_path, "w", newline="") as f:
+                        writer = csv.writer(f)
+                        writer.writerow(["dali_address", "name", "area", "unique_id"])
+                        for address, cfg in light_config.items():
+                            writer.writerow(
+                                [
+                                    address,
+                                    cfg.get("name", ""),
+                                    cfg.get("area", ""),
+                                    cfg.get("unique_id", ""),
+                                ]
+                            )
+                    return self.async_create_entry(
+                        title="", data=self.config_entry.options
+                    )
+                except OSError as err:
+                    _LOGGER.error("Error writing backup file: %s", err)
+                    errors["base"] = "write_failed"
+
+        return self.async_show_form(
+            step_id="backup_config",
+            data_schema=vol.Schema({vol.Required("file_path"): str}),
             errors=errors,
         )
 

--- a/custom_components/foxtron_dali/translations/en.json
+++ b/custom_components/foxtron_dali/translations/en.json
@@ -25,7 +25,8 @@
                 "menu_options": {
                     "discover_buttons": "Discover Buttons",
                     "set_fade_time": "Set Fade Time",
-                    "upload_config": "Upload Light Configuration"
+                    "upload_config": "Upload Light Configuration",
+                    "backup_config": "Backup Light Configuration"
                 }
             },
             "discover_buttons": {
@@ -48,12 +49,21 @@
                 "data": {
                     "file_path": "Path to CSV file"
                 }
+            },
+            "backup_config": {
+                "title": "Backup Light Configuration",
+                "description": "Export the current light configuration to a CSV file.",
+                "data": {
+                    "file_path": "Path to save CSV file"
+                }
             }
         },
         "error": {
             "invalid_csv_header": "Invalid CSV header. The header must be: dali_address,name,area,unique_id",
             "file_not_found": "File not found. Please check the path and try again.",
-            "invalid_file": "The uploaded file is not a valid CSV file."
+            "invalid_file": "The uploaded file is not a valid CSV file.",
+            "write_failed": "Failed to write to file. Please check the path and try again.",
+            "no_config": "No light configuration to backup."
         }
     }
 }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -122,6 +122,33 @@ async def test_upload_config_file_not_found(hass, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_backup_config_success(hass, tmp_path):
+    """Test successful backup of light configuration."""
+    backup_path = tmp_path / "backup.csv"
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={
+            "light_config": {1: {"name": "Light", "area": "Room", "unique_id": "uid1"}}
+        },
+    )
+    entry.add_to_hass(hass)
+    flow = config_flow.FoxtronDaliOptionsFlowHandler(entry)
+    flow.hass = hass
+
+    result = await flow.async_step_backup_config(
+        user_input={"file_path": str(backup_path)}
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    lines = backup_path.read_text().splitlines()
+    assert lines == [
+        "dali_address,name,area,unique_id",
+        "1,Light,Room,uid1",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_discover_buttons_merges_options(hass):
     """Test discovered buttons are merged into options."""
     entry = MockConfigEntry(domain=DOMAIN, data={}, options={"buttons": ["1-1"]})


### PR DESCRIPTION
## Summary
- add "Backup Light Configuration" option to Foxtron DALI options
- implement export of current light configuration to CSV
- cover backup flow with tests

## Testing
- `pre-commit run --files custom_components/foxtron_dali/config_flow.py custom_components/foxtron_dali/translations/en.json tests/test_config_flow.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9b98468048323a7892638f27b2738