### PR TITLE
Add project metadata and dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,25 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ha-foxtron-dali"
+version = "0.1.0"
+description = "Foxtron DALI Home Assistant Integration"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "homeassistant",
+    "voluptuous",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-homeassistant-custom-component",
+    "pytest-asyncio",
+]
+
 [tool.mypy]
 python_version = "3.11"
 ignore_missing_imports = true


### PR DESCRIPTION
## Summary
- add project metadata and runtime dependencies to `pyproject.toml`
- define optional test dependencies for pytest

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_68ab475bacbc8323b9d04448a58df273