### PR TITLE
Add .gitignore for build artifacts and caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Python caches
+__pycache__/
+*.py[cod]
+
+# Build outputs
+build/
+dist/
+*.egg-info/
+
+# Tooling artifacts
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/


### PR DESCRIPTION
## Summary
- ignore Python caches, build directories, and tooling artifacts

## Testing
- `pre-commit run --files .gitignore`
- `pytest` *(fails: ModuleNotFoundError: homeassistant; attempted dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4856ab44832382bc3c1efee89308