### PR TITLE
Use host-port addresses for light IDs

### DIFF
--- a/custom_components/foxtron_dali/config_flow.py
+++ b/custom_components/foxtron_dali/config_flow.py
@@ -124,15 +124,15 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                     light_config: Dict[int, Dict[str, str]] = {}
                     entity_reg = er.async_get(self.hass)
                     area_reg = ar.async_get(self.hass)
+                    host = self.config_entry.data[CONF_HOST]
+                    port = self.config_entry.data[CONF_PORT]
                     for addr_str, cfg in data.items():
                         if not isinstance(cfg, dict):
                             raise ValueError("Invalid JSON structure")
                         address = int(addr_str)
                         name = cfg.get("name", f"DALI Light {address}")
                         area = cfg.get("area", "")
-                        unique_id = cfg.get(
-                            "unique_id", f"{self.config_entry.entry_id}_{address}"
-                        )
+                        unique_id = cfg.get("unique_id", f"{host}_{port}_{address}")
                         light_config[address] = {
                             "name": name,
                             "area": area,
@@ -142,7 +142,7 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                             "light", DOMAIN, unique_id
                         )
                         if not entity_id:
-                            default_uid = f"{self.config_entry.entry_id}_{address}"
+                            default_uid = f"{host}_{port}_{address}"
                             entity_id = entity_reg.async_get_entity_id(
                                 "light", DOMAIN, default_uid
                             )
@@ -226,11 +226,11 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                     entity_reg = er.async_get(self.hass)
                     area_reg = ar.async_get(self.hass)
                     data: Dict[int, Dict[str, str]] = {}
+                    host = self.config_entry.data[CONF_HOST]
+                    port = self.config_entry.data[CONF_PORT]
                     for address in all_addresses:
                         cfg = light_config.get(address, {})
-                        unique_id = cfg.get(
-                            "unique_id", f"{self.config_entry.entry_id}_{address}"
-                        )
+                        unique_id = cfg.get("unique_id", f"{host}_{port}_{address}")
                         entity_id = entity_reg.async_get_entity_id(
                             "light", DOMAIN, unique_id
                         )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -78,7 +78,9 @@ async def test_upload_config_success(hass, tmp_path):
         json.dumps({"1": {"name": "New Light", "area": "Room", "unique_id": "uid1"}})
     )
 
-    entry = MockConfigEntry(domain=DOMAIN, data={}, options={})
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "1.2.3.4", CONF_PORT: 23}, options={}
+    )
     entry.add_to_hass(hass)
 
     area_reg = ar.async_get(hass)
@@ -120,7 +122,9 @@ async def test_upload_config_updates_existing_unique_id(hass, tmp_path):
         json.dumps({"1": {"name": "New Light", "area": "Room", "unique_id": "uid1"}})
     )
 
-    entry = MockConfigEntry(domain=DOMAIN, data={}, options={})
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "1.2.3.4", CONF_PORT: 23}, options={}
+    )
     entry.add_to_hass(hass)
 
     area_reg = ar.async_get(hass)
@@ -131,7 +135,7 @@ async def test_upload_config_updates_existing_unique_id(hass, tmp_path):
         config_entry_id=entry.entry_id, identifiers={(DOMAIN, entry.entry_id)}
     )
     # Create entity with default unique ID
-    default_uid = f"{entry.entry_id}_1"
+    default_uid = f"{entry.data[CONF_HOST]}_{entry.data[CONF_PORT]}_1"
     entity_reg.async_get_or_create(
         "light",
         DOMAIN,
@@ -166,7 +170,9 @@ async def test_upload_config_mismatch_notification(hass, tmp_path):
         json.dumps({"1": {"name": "Light", "area": "Room", "unique_id": "uid1"}})
     )
 
-    entry = MockConfigEntry(domain=DOMAIN, data={}, options={})
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "1.2.3.4", CONF_PORT: 23}, options={}
+    )
     entry.add_to_hass(hass)
 
     area_reg = ar.async_get(hass)
@@ -176,7 +182,7 @@ async def test_upload_config_mismatch_notification(hass, tmp_path):
     device = device_reg.async_get_or_create(
         config_entry_id=entry.entry_id, identifiers={(DOMAIN, entry.entry_id)}
     )
-    default_uid = f"{entry.entry_id}_1"
+    default_uid = f"{entry.data[CONF_HOST]}_{entry.data[CONF_PORT]}_1"
     entity_reg.async_get_or_create(
         "light",
         DOMAIN,
@@ -207,7 +213,9 @@ async def test_upload_config_invalid_json(hass, tmp_path):
     bad_path = tmp_path / "bad.json"
     bad_path.write_text("not a json")
 
-    entry = MockConfigEntry(domain=DOMAIN, data={}, options={})
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "1.2.3.4", CONF_PORT: 23}, options={}
+    )
     entry.add_to_hass(hass)
     flow = config_flow.FoxtronDaliOptionsFlowHandler(entry)
     flow.hass = hass
@@ -225,7 +233,9 @@ async def test_upload_config_file_not_found(hass, tmp_path):
     """Test JSON upload with missing file."""
     missing = tmp_path / "missing.json"
 
-    entry = MockConfigEntry(domain=DOMAIN, data={}, options={})
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "1.2.3.4", CONF_PORT: 23}, options={}
+    )
     entry.add_to_hass(hass)
     flow = config_flow.FoxtronDaliOptionsFlowHandler(entry)
     flow.hass = hass
@@ -242,7 +252,7 @@ async def test_backup_config_success(hass, tmp_path):
     backup_path = tmp_path / "backup.json"
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={},
+        data={CONF_HOST: "1.2.3.4", CONF_PORT: 23},
         options={
             "light_config": {1: {"name": "Light", "area": "Room", "unique_id": "uid1"}}
         },
@@ -265,7 +275,9 @@ async def test_backup_config_uses_entity_area(hass, tmp_path):
     """Export uses entity name and entity area."""
     backup_path = tmp_path / "backup.json"
     entry = MockConfigEntry(
-        domain=DOMAIN, data={}, options={"light_config": {1: {"unique_id": "uid1"}}}
+        domain=DOMAIN,
+        data={CONF_HOST: "1.2.3.4", CONF_PORT: 23},
+        options={"light_config": {1: {"unique_id": "uid1"}}},
     )
     entry.add_to_hass(hass)
 
@@ -302,7 +314,9 @@ async def test_backup_config_uses_entity_area(hass, tmp_path):
 async def test_backup_config_discovers_devices(hass, tmp_path):
     """Backup uses discovered devices when no config is present."""
     backup_path = tmp_path / "backup.json"
-    entry = MockConfigEntry(domain=DOMAIN, data={}, options={})
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "1.2.3.4", CONF_PORT: 23}, options={}
+    )
     entry.add_to_hass(hass)
 
     driver = AsyncMock()
@@ -319,8 +333,16 @@ async def test_backup_config_discovers_devices(hass, tmp_path):
     assert result["type"] == FlowResultType.CREATE_ENTRY
     data = json.loads(backup_path.read_text())
     assert data == {
-        "1": {"name": "DALI Light 1", "area": "", "unique_id": f"{entry.entry_id}_1"},
-        "2": {"name": "DALI Light 2", "area": "", "unique_id": f"{entry.entry_id}_2"},
+        "1": {
+            "name": "DALI Light 1",
+            "area": "",
+            "unique_id": f"{entry.data[CONF_HOST]}_{entry.data[CONF_PORT]}_1",
+        },
+        "2": {
+            "name": "DALI Light 2",
+            "area": "",
+            "unique_id": f"{entry.data[CONF_HOST]}_{entry.data[CONF_PORT]}_2",
+        },
     }
 
 
@@ -328,7 +350,9 @@ async def test_backup_config_discovers_devices(hass, tmp_path):
 async def test_backup_config_no_config(hass, tmp_path):
     """Backing up with no devices or config returns an error."""
     backup_path = tmp_path / "backup.json"
-    entry = MockConfigEntry(domain=DOMAIN, data={}, options={})
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "1.2.3.4", CONF_PORT: 23}, options={}
+    )
     entry.add_to_hass(hass)
 
     driver = AsyncMock()
@@ -349,7 +373,11 @@ async def test_backup_config_no_config(hass, tmp_path):
 @pytest.mark.asyncio
 async def test_discover_buttons_merges_options(hass):
     """Test discovered buttons are merged into options."""
-    entry = MockConfigEntry(domain=DOMAIN, data={}, options={"buttons": ["1-1"]})
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "1.2.3.4", CONF_PORT: 23},
+        options={"buttons": ["1-1"]},
+    )
     entry.add_to_hass(hass)
 
     driver = MagicMock()

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from homeassistant.const import CONF_HOST, CONF_PORT
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -22,6 +23,7 @@ async def test_async_turn_on_off_sends_dali_levels_and_updates_state():
     driver.set_device_level = AsyncMock()
     entry = MagicMock()
     entry.entry_id = "entry1"
+    entry.data = {CONF_HOST: "1.2.3.4", CONF_PORT: 23}
 
     light = DaliLight(driver, address=1, entry=entry, config={})
     light.async_write_ha_state = MagicMock()
@@ -44,6 +46,7 @@ async def test_handle_dali_command_events_updates_state():
     driver = MagicMock()
     entry = MagicMock()
     entry.entry_id = "entry1"
+    entry.data = {CONF_HOST: "1.2.3.4", CONF_PORT: 23}
 
     light = DaliLight(driver, address=1, entry=entry, config={})
     light.async_write_ha_state = MagicMock()
@@ -77,6 +80,7 @@ async def test_light_attached_to_bus_device():
     driver = MagicMock()
     entry = MagicMock()
     entry.entry_id = "bus1"
+    entry.data = {CONF_HOST: "1.2.3.4", CONF_PORT: 23}
 
     light = DaliLight(driver, address=1, entry=entry, config={})
 


### PR DESCRIPTION
## Summary
- Generate light unique IDs from gateway host, port, and DALI address
- Split host/port-based unique IDs to recover DALI address
- Import names even when entity IDs change by matching unique IDs

## Testing
- `pre-commit run --files custom_components/foxtron_dali/light.py custom_components/foxtron_dali/__init__.py custom_components/foxtron_dali/config_flow.py tests/test_services.py tests/test_config_flow.py tests/test_light.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab53a49e60832382d6f9d400afd96b