### PR TITLE
Support hidden and disabled flags in name import/export

### DIFF
--- a/custom_components/foxtron_dali/__init__.py
+++ b/custom_components/foxtron_dali/__init__.py
@@ -128,6 +128,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     "area": area_name,
                     "device_id": device_id,
                     "device_name": device_name,
+                    "hidden_by": entry.hidden_by,
+                    "disabled_by": entry.disabled_by,
                 }
 
             store = storage.Store(hass, STORE_VERSION, path)
@@ -164,6 +166,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     area = area_reg.async_get_area_by_name(area_name)
                     if area:
                         updates["area_id"] = area.id
+                if "hidden_by" in item:
+                    updates["hidden_by"] = (
+                        er.RegistryEntryHider(item["hidden_by"])
+                        if item["hidden_by"] is not None
+                        else None
+                    )
+                if "disabled_by" in item:
+                    updates["disabled_by"] = (
+                        er.RegistryEntryDisabler(item["disabled_by"])
+                        if item["disabled_by"] is not None
+                        else None
+                    )
                 if updates:
                     ent_reg.async_update_entity(entity_id, **updates)
                 device_id = item.get("device_id")

--- a/custom_components/foxtron_dali/services.yaml
+++ b/custom_components/foxtron_dali/services.yaml
@@ -22,7 +22,10 @@ set_fade_time:
           max: 15
 
 export_names:
-  description: Export DALI address to name mappings to a JSON file.
+  description: |
+    Export DALI address to name mappings to a JSON file.
+    Each entry includes entity ID, unique ID, name, area, device info, and
+    `hidden_by`/`disabled_by` flags.
   fields:
     path:
       description: Optional path within the Home Assistant config directory.
@@ -31,7 +34,10 @@ export_names:
         text:
 
 import_names:
-  description: Import DALI address to name mappings from a JSON file.
+  description: |
+    Import DALI address to name mappings from a JSON file created by
+    `export_names`. Restores name, area, device name, and
+    `hidden_by`/`disabled_by` flags for matching entities.
   fields:
     path:
       description: Optional path within the Home Assistant config directory.

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -49,7 +49,13 @@ async def test_export_import_round_trip(hass, tmp_path, enable_custom_integratio
         config_entry=entry,
         device_id=device.id,
     )
-    ent_reg.async_update_entity(entity.entity_id, name="Orig Light", area_id=area.id)
+    ent_reg.async_update_entity(
+        entity.entity_id,
+        name="Orig Light",
+        area_id=area.id,
+        hidden_by=er.RegistryEntryHider.USER,
+        disabled_by=er.RegistryEntryDisabler.USER,
+    )
 
     class FakeStore:
         def __init__(self, hass, version, key):
@@ -77,6 +83,8 @@ async def test_export_import_round_trip(hass, tmp_path, enable_custom_integratio
             "area": "Old Area",
             "device_id": device.id,
             "device_name": "Orig Device",
+            "hidden_by": "user",
+            "disabled_by": "user",
         }
     }
 
@@ -98,7 +106,13 @@ async def test_export_import_round_trip(hass, tmp_path, enable_custom_integratio
         config_entry=entry2,
         device_id=device2.id,
     )
-    ent_reg.async_update_entity(new_entity.entity_id, name="Changed", area_id=None)
+    ent_reg.async_update_entity(
+        new_entity.entity_id,
+        name="Changed",
+        area_id=None,
+        hidden_by=None,
+        disabled_by=None,
+    )
 
     with patch("custom_components.foxtron_dali.storage.Store", FakeStore):
         await hass.services.async_call(
@@ -108,3 +122,5 @@ async def test_export_import_round_trip(hass, tmp_path, enable_custom_integratio
     restored = ent_reg.async_get(new_entity.entity_id)
     assert restored.name == "Orig Light"
     assert restored.area_id == area.id
+    assert restored.hidden_by == er.RegistryEntryHider.USER
+    assert restored.disabled_by == er.RegistryEntryDisabler.USER


### PR DESCRIPTION
## Summary
- export entity `hidden_by` and `disabled_by` when saving names
- restore `hidden_by` and `disabled_by` on import
- document import/export behaviour and test round-trip

## Testing
- `pre-commit run --files custom_components/foxtron_dali/__init__.py custom_components/foxtron_dali/services.yaml tests/test_services.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab587024048323ac0422c2bfebb94d