### PR TITLE
Include entity flags in config backup

### DIFF
--- a/custom_components/foxtron_dali/config_flow.py
+++ b/custom_components/foxtron_dali/config_flow.py
@@ -121,7 +121,7 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                     data = json.load(f)
                     if not isinstance(data, dict):
                         raise ValueError("Invalid JSON structure")
-                    light_config: Dict[int, Dict[str, str]] = {}
+                    light_config: Dict[int, Dict[str, Any]] = {}
                     entity_reg = er.async_get(self.hass)
                     area_reg = ar.async_get(self.hass)
                     host = self.config_entry.data[CONF_HOST]
@@ -133,10 +133,14 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                         name = cfg.get("name", f"DALI Light {address}")
                         area = cfg.get("area", "")
                         unique_id = cfg.get("unique_id", f"{host}_{port}_{address}")
+                        hidden_by = cfg.get("hidden_by")
+                        disabled_by = cfg.get("disabled_by")
                         light_config[address] = {
                             "name": name,
                             "area": area,
                             "unique_id": unique_id,
+                            "hidden_by": hidden_by,
+                            "disabled_by": disabled_by,
                         }
                         entity_id = entity_reg.async_get_entity_id(
                             "light", DOMAIN, unique_id
@@ -152,6 +156,18 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                                 area_obj = area_reg.async_get_or_create(area)
                             area_id = area_obj.id if area_obj else None
                             updates = {"name": name, "area_id": area_id}
+                            if "hidden_by" in cfg:
+                                updates["hidden_by"] = (
+                                    er.RegistryEntryHider(hidden_by)
+                                    if hidden_by is not None
+                                    else None
+                                )
+                            if "disabled_by" in cfg:
+                                updates["disabled_by"] = (
+                                    er.RegistryEntryDisabler(disabled_by)
+                                    if disabled_by is not None
+                                    else None
+                                )
                             entry = entity_reg.async_get(entity_id)
                             if entry and entry.unique_id != unique_id:
                                 updates["new_unique_id"] = unique_id
@@ -225,7 +241,7 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                 else:
                     entity_reg = er.async_get(self.hass)
                     area_reg = ar.async_get(self.hass)
-                    data: Dict[int, Dict[str, str]] = {}
+                    data: Dict[int, Dict[str, Any]] = {}
                     host = self.config_entry.data[CONF_HOST]
                     port = self.config_entry.data[CONF_PORT]
                     for address in all_addresses:
@@ -236,6 +252,8 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                         )
                         name = cfg.get("name", f"DALI Light {address}")
                         area_name = cfg.get("area", "")
+                        hidden_by = None
+                        disabled_by = None
                         if entity_id:
                             entry = entity_reg.async_get(entity_id)
                             if entry:
@@ -249,11 +267,17 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                                     name = state.name
                                 elif entry.name:
                                     name = entry.name
+                                if entry.hidden_by is not None:
+                                    hidden_by = entry.hidden_by.value
+                                if entry.disabled_by is not None:
+                                    disabled_by = entry.disabled_by.value
 
                         data[address] = {
                             "name": name,
                             "area": area_name,
                             "unique_id": unique_id,
+                            "hidden_by": hidden_by,
+                            "disabled_by": disabled_by,
                         }
 
                     with open(file_path, "w", encoding="utf-8") as f:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -75,7 +75,17 @@ async def test_upload_config_success(hass, tmp_path):
     """Test successful JSON upload handling."""
     json_path = tmp_path / "lights.json"
     json_path.write_text(
-        json.dumps({"1": {"name": "New Light", "area": "Room", "unique_id": "uid1"}})
+        json.dumps(
+            {
+                "1": {
+                    "name": "New Light",
+                    "area": "Room",
+                    "unique_id": "uid1",
+                    "hidden_by": "user",
+                    "disabled_by": "user",
+                }
+            }
+        )
     )
 
     entry = MockConfigEntry(
@@ -107,11 +117,19 @@ async def test_upload_config_success(hass, tmp_path):
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"]["light_config"] == {
-        1: {"name": "New Light", "area": "Room", "unique_id": "uid1"}
+        1: {
+            "name": "New Light",
+            "area": "Room",
+            "unique_id": "uid1",
+            "hidden_by": "user",
+            "disabled_by": "user",
+        }
     }
     entity_entry = entity_reg.async_get(entity.entity_id)
     assert entity_entry.name == "New Light"
     assert entity_entry.area_id == room.id
+    assert entity_entry.hidden_by == er.RegistryEntryHider.USER
+    assert entity_entry.disabled_by == er.RegistryEntryDisabler.USER
 
 
 @pytest.mark.asyncio
@@ -267,7 +285,15 @@ async def test_backup_config_success(hass, tmp_path):
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     data = json.loads(backup_path.read_text())
-    assert data == {"1": {"name": "Light", "area": "Room", "unique_id": "uid1"}}
+    assert data == {
+        "1": {
+            "name": "Light",
+            "area": "Room",
+            "unique_id": "uid1",
+            "hidden_by": None,
+            "disabled_by": None,
+        }
+    }
 
 
 @pytest.mark.asyncio
@@ -296,7 +322,13 @@ async def test_backup_config_uses_entity_area(hass, tmp_path):
         suggested_object_id="dali_light_1",
         device_id=device.id,
     )
-    entity_reg.async_update_entity(entity.entity_id, name="Friendly", area_id=room.id)
+    entity_reg.async_update_entity(
+        entity.entity_id,
+        name="Friendly",
+        area_id=room.id,
+        hidden_by=er.RegistryEntryHider.USER,
+        disabled_by=er.RegistryEntryDisabler.USER,
+    )
 
     flow = config_flow.FoxtronDaliOptionsFlowHandler(entry)
     flow.hass = hass
@@ -307,7 +339,15 @@ async def test_backup_config_uses_entity_area(hass, tmp_path):
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     data = json.loads(backup_path.read_text())
-    assert data == {"1": {"name": "Friendly", "area": "Room", "unique_id": "uid1"}}
+    assert data == {
+        "1": {
+            "name": "Friendly",
+            "area": "Room",
+            "unique_id": "uid1",
+            "hidden_by": "user",
+            "disabled_by": "user",
+        }
+    }
 
 
 @pytest.mark.asyncio
@@ -337,11 +377,15 @@ async def test_backup_config_discovers_devices(hass, tmp_path):
             "name": "DALI Light 1",
             "area": "",
             "unique_id": f"{entry.data[CONF_HOST]}_{entry.data[CONF_PORT]}_1",
+            "hidden_by": None,
+            "disabled_by": None,
         },
         "2": {
             "name": "DALI Light 2",
             "area": "",
             "unique_id": f"{entry.data[CONF_HOST]}_{entry.data[CONF_PORT]}_2",
+            "hidden_by": None,
+            "disabled_by": None,
         },
     }
 


### PR DESCRIPTION
## Summary
- export `hidden_by` and `disabled_by` fields when backing up light configuration
- restore these entity flags during config upload
- cover new behavior in config flow tests

## Testing
- `pre-commit run --files custom_components/foxtron_dali/config_flow.py tests/test_config_flow.py`
- `pip install -e .[test]` *(failed: Operation cancelled by user)*
- `pytest` *(failed: No module named 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_68ab70692cbc8323b556efa0d807aa21