### PR TITLE
Include entity flags in config backup

### DIFF
--- a/custom_components/foxtron_dali/__init__.py
+++ b/custom_components/foxtron_dali/__init__.py
@@ -121,6 +121,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     device = dev_reg.async_get(device_id)
                     if device:
                         device_name = device.name_by_user or device.name
+                hidden_by = entry.hidden_by.value if entry.hidden_by else None
+                disabled_by = entry.disabled_by.value if entry.disabled_by else None
                 data[address] = {
                     "entity_id": entry.entity_id,
                     "unique_id": entry.unique_id,
@@ -128,9 +130,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     "area": area_name,
                     "device_id": device_id,
                     "device_name": device_name,
-                    "hidden_by": entry.hidden_by,
-                    "disabled_by": entry.disabled_by,
                 }
+                if hidden_by is not None:
+                    data[address]["hidden_by"] = hidden_by
+                if disabled_by is not None:
+                    data[address]["disabled_by"] = disabled_by
 
             store = storage.Store(hass, STORE_VERSION, path)
             await store.async_save(data)

--- a/custom_components/foxtron_dali/config_flow.py
+++ b/custom_components/foxtron_dali/config_flow.py
@@ -121,7 +121,7 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                     data = json.load(f)
                     if not isinstance(data, dict):
                         raise ValueError("Invalid JSON structure")
-                    light_config: Dict[int, Dict[str, str]] = {}
+                    light_config: Dict[int, Dict[str, Any]] = {}
                     entity_reg = er.async_get(self.hass)
                     area_reg = ar.async_get(self.hass)
                     host = self.config_entry.data[CONF_HOST]
@@ -133,11 +133,17 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                         name = cfg.get("name", f"DALI Light {address}")
                         area = cfg.get("area", "")
                         unique_id = cfg.get("unique_id", f"{host}_{port}_{address}")
+                        hidden_by = cfg.get("hidden_by")
+                        disabled_by = cfg.get("disabled_by")
                         light_config[address] = {
                             "name": name,
                             "area": area,
                             "unique_id": unique_id,
                         }
+                        if "hidden_by" in cfg:
+                            light_config[address]["hidden_by"] = hidden_by
+                        if "disabled_by" in cfg:
+                            light_config[address]["disabled_by"] = disabled_by
                         entity_id = entity_reg.async_get_entity_id(
                             "light", DOMAIN, unique_id
                         )
@@ -152,6 +158,18 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                                 area_obj = area_reg.async_get_or_create(area)
                             area_id = area_obj.id if area_obj else None
                             updates = {"name": name, "area_id": area_id}
+                            if "hidden_by" in cfg:
+                                updates["hidden_by"] = (
+                                    er.RegistryEntryHider(hidden_by)
+                                    if hidden_by is not None
+                                    else None
+                                )
+                            if "disabled_by" in cfg:
+                                updates["disabled_by"] = (
+                                    er.RegistryEntryDisabler(disabled_by)
+                                    if disabled_by is not None
+                                    else None
+                                )
                             entry = entity_reg.async_get(entity_id)
                             if entry and entry.unique_id != unique_id:
                                 updates["new_unique_id"] = unique_id
@@ -225,7 +243,7 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                 else:
                     entity_reg = er.async_get(self.hass)
                     area_reg = ar.async_get(self.hass)
-                    data: Dict[int, Dict[str, str]] = {}
+                    data: Dict[int, Dict[str, Any]] = {}
                     host = self.config_entry.data[CONF_HOST]
                     port = self.config_entry.data[CONF_PORT]
                     for address in all_addresses:
@@ -236,6 +254,8 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                         )
                         name = cfg.get("name", f"DALI Light {address}")
                         area_name = cfg.get("area", "")
+                        hidden_by = None
+                        disabled_by = None
                         if entity_id:
                             entry = entity_reg.async_get(entity_id)
                             if entry:
@@ -249,12 +269,19 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                                     name = state.name
                                 elif entry.name:
                                     name = entry.name
-
+                                if entry.hidden_by is not None:
+                                    hidden_by = entry.hidden_by.value
+                                if entry.disabled_by is not None:
+                                    disabled_by = entry.disabled_by.value
                         data[address] = {
                             "name": name,
                             "area": area_name,
                             "unique_id": unique_id,
                         }
+                        if hidden_by is not None:
+                            data[address]["hidden_by"] = hidden_by
+                        if disabled_by is not None:
+                            data[address]["disabled_by"] = disabled_by
 
                     with open(file_path, "w", encoding="utf-8") as f:
                         json.dump(data, f, indent=2)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -24,7 +24,13 @@ async def test_export_import_round_trip(hass, tmp_path, enable_custom_integratio
     entry.add_to_hass(hass)
     hass.config.config_dir = str(tmp_path)
 
-    with patch("custom_components.foxtron_dali.FoxtronDaliDriver") as mock_driver_cls:
+    with (
+        patch("custom_components.foxtron_dali.FoxtronDaliDriver") as mock_driver_cls,
+        patch(
+            "homeassistant.config_entries.ConfigEntries.async_forward_entry_setups",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
         driver = AsyncMock()
         mock_driver_cls.return_value = driver
         await foxtron_dali.async_setup_entry(hass, entry)


### PR DESCRIPTION
## Summary
- export `hidden_by` and `disabled_by` fields when backing up light configuration
- restore these entity flags on config upload
- omit `hidden_by`/`disabled_by` when not set
- align light config mapping with `main`
- stub platform forwarding in service test to avoid custom component lookup failure

## Testing
- `pre-commit run --files custom_components/foxtron_dali/__init__.py custom_components/foxtron_dali/config_flow.py tests/test_config_flow.py tests/test_services.py`
- `pip install -e .[test]`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab70692cbc8323b556efa0d807aa21