### PR TITLE
Add pre-commit dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ test = [
     "pytest-homeassistant-custom-component",
     "pytest-asyncio",
 ]
+dev = [
+    "pre-commit",
+]
 
 [tool.mypy]
 python_version = "3.11"


### PR DESCRIPTION
## Summary
- include pre-commit in dev extra to install with `pip install -e .[dev]`

## Testing
- `pre-commit run --files pyproject.toml`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_68ab7a1ac14c83239411967f79cba5f4