### PR TITLE
Remove hidden_by and disabled_by from config import/export

### DIFF
--- a/custom_components/foxtron_dali/__init__.py
+++ b/custom_components/foxtron_dali/__init__.py
@@ -128,8 +128,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     "area": area_name,
                     "device_id": device_id,
                     "device_name": device_name,
-                    "hidden_by": entry.hidden_by,
-                    "disabled_by": entry.disabled_by,
                 }
 
             store = storage.Store(hass, STORE_VERSION, path)
@@ -166,18 +164,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     area = area_reg.async_get_area_by_name(area_name)
                     if area:
                         updates["area_id"] = area.id
-                if "hidden_by" in item:
-                    updates["hidden_by"] = (
-                        er.RegistryEntryHider(item["hidden_by"])
-                        if item["hidden_by"] is not None
-                        else None
-                    )
-                if "disabled_by" in item:
-                    updates["disabled_by"] = (
-                        er.RegistryEntryDisabler(item["disabled_by"])
-                        if item["disabled_by"] is not None
-                        else None
-                    )
                 if updates:
                     ent_reg.async_update_entity(entity_id, **updates)
                 device_id = item.get("device_id")

--- a/custom_components/foxtron_dali/config_flow.py
+++ b/custom_components/foxtron_dali/config_flow.py
@@ -133,14 +133,10 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                         name = cfg.get("name", f"DALI Light {address}")
                         area = cfg.get("area", "")
                         unique_id = cfg.get("unique_id", f"{host}_{port}_{address}")
-                        hidden_by = cfg.get("hidden_by")
-                        disabled_by = cfg.get("disabled_by")
                         light_config[address] = {
                             "name": name,
                             "area": area,
                             "unique_id": unique_id,
-                            "hidden_by": hidden_by,
-                            "disabled_by": disabled_by,
                         }
                         entity_id = entity_reg.async_get_entity_id(
                             "light", DOMAIN, unique_id
@@ -156,18 +152,6 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                                 area_obj = area_reg.async_get_or_create(area)
                             area_id = area_obj.id if area_obj else None
                             updates = {"name": name, "area_id": area_id}
-                            if "hidden_by" in cfg:
-                                updates["hidden_by"] = (
-                                    er.RegistryEntryHider(hidden_by)
-                                    if hidden_by is not None
-                                    else None
-                                )
-                            if "disabled_by" in cfg:
-                                updates["disabled_by"] = (
-                                    er.RegistryEntryDisabler(disabled_by)
-                                    if disabled_by is not None
-                                    else None
-                                )
                             entry = entity_reg.async_get(entity_id)
                             if entry and entry.unique_id != unique_id:
                                 updates["new_unique_id"] = unique_id
@@ -252,8 +236,6 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                         )
                         name = cfg.get("name", f"DALI Light {address}")
                         area_name = cfg.get("area", "")
-                        hidden_by = None
-                        disabled_by = None
                         if entity_id:
                             entry = entity_reg.async_get(entity_id)
                             if entry:
@@ -267,17 +249,11 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                                     name = state.name
                                 elif entry.name:
                                     name = entry.name
-                                if entry.hidden_by is not None:
-                                    hidden_by = entry.hidden_by.value
-                                if entry.disabled_by is not None:
-                                    disabled_by = entry.disabled_by.value
 
                         data[address] = {
                             "name": name,
                             "area": area_name,
                             "unique_id": unique_id,
-                            "hidden_by": hidden_by,
-                            "disabled_by": disabled_by,
                         }
 
                     with open(file_path, "w", encoding="utf-8") as f:

--- a/custom_components/foxtron_dali/services.yaml
+++ b/custom_components/foxtron_dali/services.yaml
@@ -24,8 +24,7 @@ set_fade_time:
 export_names:
   description: |
     Export DALI address to name mappings to a JSON file.
-    Each entry includes entity ID, unique ID, name, area, device info, and
-    `hidden_by`/`disabled_by` flags.
+    Each entry includes entity ID, unique ID, name, area, and device info.
   fields:
     path:
       description: Optional path within the Home Assistant config directory.
@@ -36,8 +35,7 @@ export_names:
 import_names:
   description: |
     Import DALI address to name mappings from a JSON file created by
-    `export_names`. Restores name, area, device name, and
-    `hidden_by`/`disabled_by` flags for matching entities.
+    `export_names`. Restores name, area, and device name for matching entities.
   fields:
     path:
       description: Optional path within the Home Assistant config directory.

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -81,8 +81,6 @@ async def test_upload_config_success(hass, tmp_path):
                     "name": "New Light",
                     "area": "Room",
                     "unique_id": "uid1",
-                    "hidden_by": "user",
-                    "disabled_by": "user",
                 }
             }
         )
@@ -121,15 +119,13 @@ async def test_upload_config_success(hass, tmp_path):
             "name": "New Light",
             "area": "Room",
             "unique_id": "uid1",
-            "hidden_by": "user",
-            "disabled_by": "user",
         }
     }
     entity_entry = entity_reg.async_get(entity.entity_id)
     assert entity_entry.name == "New Light"
     assert entity_entry.area_id == room.id
-    assert entity_entry.hidden_by == er.RegistryEntryHider.USER
-    assert entity_entry.disabled_by == er.RegistryEntryDisabler.USER
+    assert entity_entry.hidden_by is None
+    assert entity_entry.disabled_by is None
 
 
 @pytest.mark.asyncio
@@ -290,8 +286,6 @@ async def test_backup_config_success(hass, tmp_path):
             "name": "Light",
             "area": "Room",
             "unique_id": "uid1",
-            "hidden_by": None,
-            "disabled_by": None,
         }
     }
 
@@ -326,8 +320,6 @@ async def test_backup_config_uses_entity_area(hass, tmp_path):
         entity.entity_id,
         name="Friendly",
         area_id=room.id,
-        hidden_by=er.RegistryEntryHider.USER,
-        disabled_by=er.RegistryEntryDisabler.USER,
     )
 
     flow = config_flow.FoxtronDaliOptionsFlowHandler(entry)
@@ -344,8 +336,6 @@ async def test_backup_config_uses_entity_area(hass, tmp_path):
             "name": "Friendly",
             "area": "Room",
             "unique_id": "uid1",
-            "hidden_by": "user",
-            "disabled_by": "user",
         }
     }
 
@@ -377,15 +367,11 @@ async def test_backup_config_discovers_devices(hass, tmp_path):
             "name": "DALI Light 1",
             "area": "",
             "unique_id": f"{entry.data[CONF_HOST]}_{entry.data[CONF_PORT]}_1",
-            "hidden_by": None,
-            "disabled_by": None,
         },
         "2": {
             "name": "DALI Light 2",
             "area": "",
             "unique_id": f"{entry.data[CONF_HOST]}_{entry.data[CONF_PORT]}_2",
-            "hidden_by": None,
-            "disabled_by": None,
         },
     }
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -83,8 +83,6 @@ async def test_export_import_round_trip(hass, tmp_path, enable_custom_integratio
             "area": "Old Area",
             "device_id": device.id,
             "device_name": "Orig Device",
-            "hidden_by": "user",
-            "disabled_by": "user",
         }
     }
 
@@ -122,5 +120,5 @@ async def test_export_import_round_trip(hass, tmp_path, enable_custom_integratio
     restored = ent_reg.async_get(new_entity.entity_id)
     assert restored.name == "Orig Light"
     assert restored.area_id == area.id
-    assert restored.hidden_by == er.RegistryEntryHider.USER
-    assert restored.disabled_by == er.RegistryEntryDisabler.USER
+    assert restored.hidden_by is None
+    assert restored.disabled_by is None


### PR DESCRIPTION
## Summary
- drop `hidden_by`/`disabled_by` from DALI name export and import services
- stop handling `hidden_by`/`disabled_by` in options flow backup/import helpers
- update tests for removed fields

## Testing
- `pre-commit run --files custom_components/foxtron_dali/__init__.py custom_components/foxtron_dali/config_flow.py custom_components/foxtron_dali/services.yaml tests/test_config_flow.py tests/test_services.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab7fd247348323b06392981718b051