### PR TITLE
Derive light backup filename from bus details

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ After setup, you can adjust additional settings by clicking **CONFIGURE** on the
 
 *   **Default Fade Time:** Sets the default DALI fade time (0-15) for all lights on this bus.
 *   **Discovered Buttons:** This section is used to manage and add newly discovered DALI buttons.
+*   **Light Configuration Import/Export:** Save or restore light names and areas
+    using a JSON file. The default filename is derived from the gateway's IP
+    address and port, and any existing file with that name will be overwritten.
 
 ## Usage
 

--- a/custom_components/foxtron_dali/config_flow.py
+++ b/custom_components/foxtron_dali/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import (
 from homeassistant.components import persistent_notification
 
 
-from .const import DOMAIN, LIGHT_CONFIG_FILE
+from .const import DOMAIN, light_config_filename
 from .driver import FoxtronDaliDriver, format_button_id, parse_button_id
 from .event import (
     DEFAULT_LONG_PRESS_THRESHOLD,
@@ -191,15 +191,14 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                 _LOGGER.error("Error processing config file: %s", e)
                 errors["base"] = "invalid_json"
 
+        host = self.config_entry.data[CONF_HOST]
+        port = self.config_entry.data[CONF_PORT]
+        default_path = self.hass.config.path(light_config_filename(host, port))
+
         return self.async_show_form(
             step_id="upload_config",
             data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        "file_path",
-                        default=self.hass.config.path(LIGHT_CONFIG_FILE),
-                    ): str,
-                }
+                {vol.Required("file_path", default=default_path): str}
             ),
             errors=errors,
         )
@@ -265,15 +264,14 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                 _LOGGER.error("Error writing backup file: %s", err)
                 errors["base"] = "write_failed"
 
+        host = self.config_entry.data[CONF_HOST]
+        port = self.config_entry.data[CONF_PORT]
+        default_path = self.hass.config.path(light_config_filename(host, port))
+
         return self.async_show_form(
             step_id="backup_config",
             data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        "file_path",
-                        default=self.hass.config.path(LIGHT_CONFIG_FILE),
-                    ): str
-                }
+                {vol.Required("file_path", default=default_path): str}
             ),
             errors=errors,
         )

--- a/custom_components/foxtron_dali/const.py
+++ b/custom_components/foxtron_dali/const.py
@@ -10,5 +10,14 @@ PLATFORMS = ["light", "event"]
 SIGNAL_DALI_EVENT = f"{DOMAIN}_event"
 
 # --- File paths ---
-# Default file used for importing and exporting light configurations
-LIGHT_CONFIG_FILE = "foxtron_dali_lights.json"
+# Template used for importing and exporting light configurations.
+# The host and port uniquely identify a DALI bus instance.
+LIGHT_CONFIG_FILE_TEMPLATE = "foxtron_dali_lights_{host}_{port}.json"
+
+
+def light_config_filename(host: str, port: int) -> str:
+    """Return the default light configuration filename for a DALI bus."""
+    # Replace separators that could appear in IPv6 or hostnames to keep the
+    # filename filesystem friendly.
+    safe_host = host.replace(":", "_")
+    return LIGHT_CONFIG_FILE_TEMPLATE.format(host=safe_host, port=port)


### PR DESCRIPTION
## Summary
- include bus host and port in default light config file name
- overwrite existing file when exporting light config
- document light config import/export options

## Testing
- `pre-commit run --files README.md custom_components/foxtron_dali/config_flow.py custom_components/foxtron_dali/const.py tests/test_config_flow.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab85e9cbec83238fc3e051ce7c20b7