### PR TITLE
Persist DALI buttons without awaiting config updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ When you first add the integration, you will be prompted for the following:
 After setup, you can adjust additional settings by clicking **CONFIGURE** on the integration card:
 
 *   **Default Fade Time:** Sets the default DALI fade time (0-15) for all lights on this bus.
-*   **Discovered Buttons:** This section is used to manage and add newly discovered DALI buttons.
+*   **Button Event Timing:** Adjust thresholds for multi-press and long-press detection.
 *   **Light Configuration Import/Export:** Save or restore light names and areas
     using a JSON file. The default filename is derived from the gateway's IP
     address and port, and any existing file with that name will be overwritten.
@@ -59,30 +59,9 @@ The integration listens for brightness commands on the DALI bus. When a light le
 
 ### Using DALI Buttons
 
-Unlike lights, DALI buttons are not actively scanned. They are discovered when they send an event. The process is as follows:
+DALI buttons are discovered passively when they send an event. Press a button once and the integration automatically adopts it and stores it in the configuration.
 
-**1. Discovery**
-
-To discover a new button, you must physically press it. When you do, the button sends an "Input Notification" event on the DALI bus, which the integration detects.
-
-**2. Adopting the Button**
-
-Once a new button is detected, a persistent notification will appear in your Home Assistant dashboard.
-
-> **New DALI buttons discovered**
-> The Foxtron DALI integration has discovered new buttons. Please go to the integration's configuration to add them.
-
-To add the button:
-1.  Go to **Settings > Devices & Services**.
-2.  Find the Foxtron DALI integration card and click **CONFIGURE**.
-3.  A list of newly discovered button IDs (formatted as `address-instance`) will be shown.
-4.  Select the button(s) you wish to add and click **Submit**.
-
-**3. Using the Button in Automations**
-
-Adding a button creates an `event` entity in Home Assistant. This entity does not have a state (like on/off) but acts as a source for events in your automations.
-
-You can trigger automations using the `dali_event` event type.
+Each button press generates events on the `DALI Button Events` entity. You can trigger automations using the `dali_event` event type. Event data includes the `button_id` (formatted as `address-instance`) and the specific `event_type` such as `short_press` or `long_press_start`.
 
 Here is an example automation that turns on a light with a short press of a DALI button:
 
@@ -93,8 +72,8 @@ automation:
       - platform: event
         event_type: dali_event
         event_data:
-          # Unique ID of the integration entry and button identifier
-          unique_id: "YOUR_CONFIG_ENTRY_ID"
+          # Unique ID of the bus and button identifier
+          unique_id: "192.168.1.50_23_button_events"
           button_id: "56-1"
           # This is the specific button action you want to react to.
           event_type: "short_press"

--- a/custom_components/foxtron_dali/event.py
+++ b/custom_components/foxtron_dali/event.py
@@ -5,6 +5,7 @@ from typing import Callable
 
 from homeassistant.components.event import EventEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -54,8 +55,11 @@ class DaliButton(EventEntity):
     def __init__(self, entry: ConfigEntry, driver: FoxtronDaliDriver) -> None:
         """Initialize the button event handler."""
         self._driver = driver
+        self._entry = entry
         self._attr_name = "DALI Button Events"
-        self._attr_unique_id = f"{entry.entry_id}_dali_button_events"
+        self._attr_unique_id = (
+            f"{entry.data[CONF_HOST]}_{entry.data[CONF_PORT]}_button_events"
+        )
         self._attr_device_info = {
             "identifiers": {(DOMAIN, entry.entry_id)},
             "name": f"DALI Bus ({entry.data['host']})",
@@ -101,7 +105,10 @@ class DaliButton(EventEntity):
         if not isinstance(event, DaliInputNotificationEvent):
             return
 
-        if event.address is None:
+        if event.address is None or event.event_code not in (
+            EVENT_BUTTON_PRESSED,
+            EVENT_BUTTON_RELEASED,
+        ):
             return
 
         key = format_button_id(event.address, event.instance_number)
@@ -116,6 +123,18 @@ class DaliButton(EventEntity):
         state.last_event_data = data
 
         if event.event_code == EVENT_BUTTON_PRESSED:
+            if key not in self._driver._known_buttons:
+                _LOGGER.info("Adopting new button %s", key)
+                self._driver.add_known_button(key)
+                buttons = list(self._entry.options.get("buttons", []))
+                if key not in buttons:
+                    buttons.append(key)
+                    new_options = dict(self._entry.options)
+                    new_options["buttons"] = buttons
+                    self.hass.config_entries.async_update_entry(
+                        self._entry, options=new_options
+                    )
+
             self._trigger_event("button_pressed", data)
 
             if state.finalize_task:
@@ -126,7 +145,7 @@ class DaliButton(EventEntity):
                 self._handle_long_press(key)
             )
 
-        elif event.event_code == EVENT_BUTTON_RELEASED:
+        else:  # EVENT_BUTTON_RELEASED
             self._trigger_event("button_released", data)
 
             if state.long_press_task:
@@ -142,9 +161,6 @@ class DaliButton(EventEntity):
                 state.finalize_task = self.hass.async_create_task(
                     self._finalize_presses(key)
                 )
-
-        else:
-            return
 
     async def _handle_long_press(self, key: str) -> None:
         """Handle long press start and repeat events for a button."""

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -54,11 +54,23 @@ class EventEntity:
         return None
 
 
+class ConfigEntries:
+    """Stub for hass.config_entries."""
+
+    def __init__(self):
+        self.updated: list[tuple[object, dict]] = []
+
+    def async_update_entry(self, entry, options=None):
+        entry.options = options or {}
+        self.updated.append((entry, entry.options))
+
+
 class HomeAssistant:
     """Minimal HomeAssistant implementation."""
 
     def __init__(self):
         self.loop = asyncio.get_event_loop()
+        self.config_entries = ConfigEntries()
 
     def async_create_task(self, coro):
         return self.loop.create_task(coro)
@@ -105,6 +117,9 @@ if TYPE_CHECKING:
 class MockDriver:
     """Minimal driver used for testing DaliButton."""
 
+    def __init__(self):
+        self._known_buttons: set[str] = set()
+
     def add_event_listener(self, callback):
         self._callback = callback
 
@@ -119,6 +134,9 @@ class MockDriver:
             if asyncio.iscoroutine(result):
                 await result
 
+    def add_known_button(self, button_id: str):
+        self._known_buttons.add(button_id)
+
 
 def _make_event(code: int) -> "_DINEvent":
     """Helper to create a DaliInputNotificationEvent with a fixed address."""
@@ -131,7 +149,7 @@ async def button():
     hass = HomeAssistant()
     entry = MagicMock()
     entry.entry_id = "entry"
-    entry.data = {"host": "test"}
+    entry.data = {"host": "test", "port": 23}
     entry.options = {}
     driver = MockDriver()
     button = DaliButton(entry, driver)
@@ -232,3 +250,24 @@ async def test_ignores_other_events(button, monkeypatch):
 
     await button._handle_event(_make_event(EVENT_LONG_PRESS_START))
     assert events == []
+
+
+@pytest.mark.asyncio
+async def test_auto_adopts_button():
+    hass = HomeAssistant()
+    entry = MagicMock()
+    entry.entry_id = "entry"
+    entry.data = {"host": "test", "port": 23}
+    entry.options = {}
+    driver = MockDriver()
+    button = DaliButton(entry, driver)
+    button.hass = hass
+    await button.async_added_to_hass()
+    button._multi_press_window = 0.01
+    await button._handle_event(_make_event(EVENT_BUTTON_PRESSED))
+    await button._handle_event(_make_event(EVENT_BUTTON_RELEASED))
+    await asyncio.sleep(0.02)
+    assert "1-1" in driver._known_buttons
+    assert entry.options["buttons"] == ["1-1"]
+    assert button.unique_id == "test_23_button_events"
+    await button.async_will_remove_from_hass()


### PR DESCRIPTION
## Summary
- Fix button adoption by calling `async_update_entry` without awaiting the return value
- Align test stub `async_update_entry` with Home Assistant's synchronous implementation

## Testing
- `pre-commit run --files custom_components/foxtron_dali/event.py tests/test_event.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aebe1ad2608323913b3436c954cb47