### PR TITLE
Avoid awaiting config entry update

### DIFF
--- a/custom_components/foxtron_dali/event.py
+++ b/custom_components/foxtron_dali/event.py
@@ -131,7 +131,7 @@ class DaliButton(EventEntity):
                     buttons.append(key)
                     new_options = dict(self._entry.options)
                     new_options["buttons"] = buttons
-                    await self.hass.config_entries.async_update_entry(
+                    self.hass.config_entries.async_update_entry(
                         self._entry, options=new_options
                     )
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -60,9 +60,10 @@ class ConfigEntries:
     def __init__(self):
         self.updated: list[tuple[object, dict]] = []
 
-    async def async_update_entry(self, entry, options=None):
+    def async_update_entry(self, entry, options=None):
         entry.options = options or {}
         self.updated.append((entry, entry.options))
+        return True
 
 
 class HomeAssistant:


### PR DESCRIPTION
## Summary
- avoid awaiting synchronous config entry updates when adopting buttons
- adjust tests to reflect sync update behavior

## Testing
- `pre-commit run --files custom_components/foxtron_dali/event.py tests/test_event.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aed3b668588323848e208b37b85907