### PR TITLE
Remove manual button discovery

### DIFF
--- a/custom_components/foxtron_dali/translations/en.json
+++ b/custom_components/foxtron_dali/translations/en.json
@@ -23,18 +23,10 @@
             "init": {
                 "title": "Foxtron DALI Options",
                 "menu_options": {
-                    "discover_buttons": "Discover Buttons",
                     "set_event_timing": "Set Event Timing",
                     "set_fade_time": "Set Fade Time",
                     "upload_config": "Upload Light Configuration",
                     "backup_config": "Backup Light Configuration"
-                }
-            },
-            "discover_buttons": {
-                "title": "Discover Buttons",
-                "description": "No new buttons have been discovered on this DALI bus. To discover buttons, physically press them. They will then appear here. Click SUBMIT to refresh the list after pressing them.",
-                "data": {
-                    "buttons": "Select buttons to add"
                 }
             },
             "set_fade_time": {

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -19,7 +19,6 @@ FoxtronMessage = driver.FoxtronMessage
 FoxtronDaliDriver = driver.FoxtronDaliDriver
 DaliCommandEvent = driver.DaliCommandEvent
 DaliInputNotificationEvent = driver.DaliInputNotificationEvent
-format_button_id = driver.format_button_id
 MSG_TYPE_DALI_EVENT_NO_ANSWER = driver.MSG_TYPE_DALI_EVENT_NO_ANSWER
 EVENT_BUTTON_PRESSED = driver.EVENT_BUTTON_PRESSED
 
@@ -33,8 +32,8 @@ def test_calculate_checksum_and_build_frame():
     assert FoxtronMessage.build_frame(payload) == expected_frame
 
 
-def test_parse_and_queue_message_events_and_button_cache():
-    """Feed sample frames and ensure events are queued and buttons cached."""
+def test_parse_and_queue_message_events():
+    """Feed sample frames and ensure events are queued."""
 
     async def run_test():
         driver_instance = FoxtronDaliDriver("host", 1234)
@@ -57,8 +56,5 @@ def test_parse_and_queue_message_events_and_button_cache():
         assert isinstance(input_event, DaliInputNotificationEvent)
         assert input_event.address == 5
         assert input_event.instance_number == 1
-
-        expected_button_id = format_button_id(5, 1)
-        assert expected_button_id in driver_instance._newly_discovered_buttons
 
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- drop manual button discovery option from config flow
- simplify driver without new-button cache
- update tests and translations

## Testing
- `pre-commit run --files custom_components/foxtron_dali/config_flow.py custom_components/foxtron_dali/driver.py custom_components/foxtron_dali/translations/en.json tests/test_config_flow.py tests/test_driver.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aed7552d3c832386ad6468574cfc6d