### PR TITLE
Avoid deprecated config entry assignment in options flow

### DIFF
--- a/custom_components/foxtron_dali/config_flow.py
+++ b/custom_components/foxtron_dali/config_flow.py
@@ -82,10 +82,6 @@ class FoxtronDaliConfigFlow(config_entries.ConfigFlow):
 class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
     """Handle an options flow for Foxtron DALI."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
-
     async def async_step_init(self, user_input: Optional[Dict[str, Any]] = None):
         """Manage the options."""
         # The user sees this menu first when they click "CONFIGURE"


### PR DESCRIPTION
## Summary
- remove explicit `config_entry` assignment in options flow to prepare for HA 2025.12

## Testing
- `pre-commit run --files custom_components/foxtron_dali/config_flow.py`
- `pytest` *(fails: AttributeError: 'FixtureDef' object has no attribute 'unittest')*


------
https://chatgpt.com/codex/tasks/task_e_68aedc1ca49083239dfc91c610923f4b