### PR TITLE
Fire DALI button events on Home Assistant bus

### DIFF
--- a/custom_components/foxtron_dali/event.py
+++ b/custom_components/foxtron_dali/event.py
@@ -100,6 +100,14 @@ class DaliButton(EventEntity):
             self._unsub()
         await super().async_will_remove_from_hass()
 
+    def _trigger_event(
+        self, event_type: str, event_attributes: dict | None = None
+    ) -> None:
+        """Fire both entity and Home Assistant bus events."""
+        super()._trigger_event(event_type, event_attributes)
+        if getattr(self.hass, "bus", None):
+            self.hass.bus.async_fire(f"{DOMAIN}_{event_type}", event_attributes or {})
+
     async def _handle_event(self, event) -> None:
         """Process a single event from the DALI driver."""
         if not isinstance(event, DaliInputNotificationEvent):


### PR DESCRIPTION
## Summary
- Fire foxtron_dali_* events on Home Assistant's event bus when DALI buttons are pressed or released
- Add test coverage for bus events and provide a minimal event bus stub

## Testing
- `pre-commit run --files custom_components/foxtron_dali/event.py tests/test_event.py`
- `pytest` *(fails: fixture 'hass' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af0130f43c8323b2ec130dbc83d185