### PR TITLE
Fix options flow initialization

### DIFF
--- a/custom_components/foxtron_dali/config_flow.py
+++ b/custom_components/foxtron_dali/config_flow.py
@@ -82,6 +82,10 @@ class FoxtronDaliConfigFlow(config_entries.ConfigFlow):
 class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
     """Handle an options flow for Foxtron DALI."""
 
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize Foxtron DALI options flow."""
+        self.config_entry = config_entry
+
     async def async_step_init(self, user_input: Optional[Dict[str, Any]] = None):
         """Manage the options."""
         # The user sees this menu first when they click "CONFIGURE"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 import sys
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant import config_entries
@@ -59,3 +59,18 @@ async def test_user_step_cannot_connect(hass):
 
         assert result["type"] == FlowResultType.FORM
         assert result["errors"]["base"] == "cannot_connect"
+
+
+@pytest.mark.asyncio
+async def test_options_flow_init():
+    """Ensure options flow initializes without error."""
+    entry = MagicMock()
+    entry.options = {}
+    entry.add_update_listener = MagicMock(return_value=MagicMock())
+
+    options_flow = config_flow.FoxtronDaliConfigFlow.async_get_options_flow(entry)
+
+    assert isinstance(options_flow, config_flow.FoxtronDaliOptionsFlowHandler)
+
+    result = await options_flow.async_step_init()
+    assert result["type"] == FlowResultType.MENU


### PR DESCRIPTION
## Summary
- handle config entry in options flow to enable options UI
- add test covering options flow initialization

## Testing
- `pre-commit run --files custom_components/foxtron_dali/config_flow.py tests/test_config_flow.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af06927b6c8323863426c35067454a