### PR TITLE
Share global options across Foxtron DALI buses

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ After setup, you can adjust additional settings by clicking **CONFIGURE** on the
     using a JSON file. The default filename is derived from the gateway's IP
     address and port, and any existing file with that name will be overwritten.
 
+All options are applied globally. Changing the configuration for one bus updates
+the settings for every configured Foxtron DALI bus.
+
 ## Usage
 
 ### Controlling Lights

--- a/custom_components/foxtron_dali/__init__.py
+++ b/custom_components/foxtron_dali/__init__.py
@@ -19,9 +19,16 @@ PLATFORMS = [Platform.LIGHT, Platform.EVENT]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Foxtron DALI from a config entry."""
+    # If this is a new entry, copy options from an existing one
+    if not entry.options:
+        for existing in hass.config_entries.async_entries(DOMAIN):
+            if existing.entry_id != entry.entry_id and existing.options:
+                hass.config_entries.async_update_entry(entry, options=existing.options)
+                entry.options = existing.options
+                break
+
     host = entry.data[CONF_HOST]
     port = entry.data[CONF_PORT]
-    # Get the list of known buttons from the config entry options
     known_buttons = entry.options.get("buttons", [])
     fade_time = entry.options.get("fade_time", 0)
 

--- a/custom_components/foxtron_dali/config_flow.py
+++ b/custom_components/foxtron_dali/config_flow.py
@@ -86,6 +86,14 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
         """Initialize Foxtron DALI options flow."""
         self.config_entry = config_entry
 
+    async def _async_update_all_entries(self, new_options: Dict[str, Any]) -> None:
+        """Update options for all config entries in this domain."""
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if entry.entry_id == self.config_entry.entry_id:
+                continue
+            self.hass.config_entries.async_update_entry(entry, options=new_options)
+            await self.hass.config_entries.async_reload(entry.entry_id)
+
     async def async_step_init(self, user_input: Optional[Dict[str, Any]] = None):
         """Manage the options."""
         # The user sees this menu first when they click "CONFIGURE"
@@ -103,6 +111,7 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
             new_options["long_press_threshold"] = user_input["long_press_threshold"]
             new_options["long_press_repeat"] = user_input["long_press_repeat"]
             new_options["multi_press_window"] = user_input["multi_press_window"]
+            await self._async_update_all_entries(new_options)
             return self.async_create_entry(title="", data=new_options)
 
         return self.async_show_form(
@@ -139,6 +148,7 @@ class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
             # Get all current options and update the fade_time
             new_options = self.config_entry.options.copy()
             new_options["fade_time"] = user_input["fade_time"]
+            await self._async_update_all_entries(new_options)
             return self.async_create_entry(title="", data=new_options)
 
         return self.async_show_form(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,42 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.const import CONF_HOST, CONF_PORT
+
+import custom_components.foxtron_dali as foxtron_dali
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_copies_existing_options():
+    """A new entry inherits options from existing entries."""
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+    hass.config_entries.async_forward_entry_setups = AsyncMock()
+    hass.data = {}
+
+    existing = MagicMock(entry_id="1", options={"fade_time": 4})
+    existing.data = {CONF_HOST: "1.1.1.1", CONF_PORT: 23}
+    existing.async_unload = AsyncMock(return_value=True)
+
+    new = MagicMock(entry_id="2", options={})
+    new.data = {CONF_HOST: "2.2.2.2", CONF_PORT: 23}
+    new.async_unload = AsyncMock(return_value=True)
+
+    hass.config_entries.async_entries.return_value = [existing, new]
+
+    driver = AsyncMock()
+    with (
+        patch("custom_components.foxtron_dali.FoxtronDaliDriver", return_value=driver),
+        patch("custom_components.foxtron_dali.dr.async_get") as mock_dr,
+        patch.object(hass.services, "has_service", return_value=False),
+        patch.object(hass.services, "async_register"),
+    ):
+        device_registry = MagicMock()
+        mock_dr.return_value = device_registry
+        device_registry.async_get_or_create = MagicMock()
+
+        assert await foxtron_dali.async_setup_entry(hass, new)
+
+    hass.config_entries.async_update_entry.assert_called_once_with(
+        new, options={"fade_time": 4}
+    )


### PR DESCRIPTION
## Summary
- propagate option changes to every Foxtron DALI bus
- copy existing options when setting up additional buses
- document global options and add regression tests

## Testing
- `pre-commit run --files custom_components/foxtron_dali/config_flow.py custom_components/foxtron_dali/__init__.py README.md tests/test_config_flow.py tests/test_init.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af657cf64083238ec1228d01f7edd7