### PR TITLE
Refactor options flow to avoid deprecated config entry

### DIFF
--- a/custom_components/foxtron_dali/config_flow.py
+++ b/custom_components/foxtron_dali/config_flow.py
@@ -79,18 +79,16 @@ class FoxtronDaliConfigFlow(config_entries.ConfigFlow):
         )
 
 
-class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithReload):
+class FoxtronDaliOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
     """Handle an options flow for Foxtron DALI."""
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize Foxtron DALI options flow."""
-        self.config_entry = config_entry
+        super().__init__(config_entry=config_entry)
 
     async def _async_update_all_entries(self, new_options: Dict[str, Any]) -> None:
         """Update options for all config entries in this domain."""
         for entry in self.hass.config_entries.async_entries(DOMAIN):
-            if entry.entry_id == self.config_entry.entry_id:
-                continue
             self.hass.config_entries.async_update_entry(entry, options=new_options)
             await self.hass.config_entries.async_reload(entry.entry_id)
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 import sys
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch, call
 
 import pytest
 from homeassistant import config_entries
@@ -92,7 +92,12 @@ async def test_options_update_applies_globally():
 
     result = await options_flow.async_step_set_fade_time({"fade_time": 5})
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    hass.config_entries.async_update_entry.assert_called_once_with(
+    hass.config_entries.async_update_entry.assert_any_call(
+        entry1, options={"fade_time": 5}
+    )
+    hass.config_entries.async_update_entry.assert_any_call(
         entry2, options={"fade_time": 5}
     )
-    hass.config_entries.async_reload.assert_awaited_once_with("2")
+    hass.config_entries.async_reload.assert_has_awaits(
+        [call("1"), call("2")], any_order=True
+    )


### PR DESCRIPTION
## Summary
- switch options flow handler to `OptionsFlowWithConfigEntry`
- reload all config entries when updating options
- adjust option flow tests for new behavior

## Testing
- `pre-commit run --files custom_components/foxtron_dali/config_flow.py tests/test_config_flow.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af75c464f4832397565d24b198fbb5