### PR TITLE
Include unique ID in button event data

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The integration listens for brightness commands on the DALI bus. When a light le
 
 DALI buttons are discovered passively when they send an event. Press a button once and the integration automatically adopts it and stores it in the configuration.
 
-Each button press generates events on the `DALI Button Events` entity. You can trigger automations using the `dali_event` event type. Event data includes the `button_id` (formatted as `address-instance`) and the specific `event_type` such as `short_press` or `long_press_start`.
+Each button press generates events on the `DALI Button Events` entity. You can trigger automations using the `dali_event` event type. Event data includes the `button_id` (formatted as `address-instance`), the gateway `unique_id` (derived from the host and port), and the specific `event_type` such as `short_press` or `long_press_start`.
 
 Here is an example automation that turns on a light with a short press of a DALI button:
 

--- a/custom_components/foxtron_dali/event.py
+++ b/custom_components/foxtron_dali/event.py
@@ -125,6 +125,7 @@ class DaliButton(EventEntity):
             "address": event.address,
             "address_type": event.address_type,
             "instance_number": event.instance_number,
+            "unique_id": self._attr_unique_id,
         }
 
         state = self._button_states.setdefault(key, _ButtonState())

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -192,6 +192,7 @@ async def test_button_pressed_and_short_press(button, monkeypatch):
             "address": 1,
             "address_type": "Short",
             "instance_number": 1,
+            "unique_id": "test_23_button_events",
         },
     )
     assert events[1][0] == "button_released"
@@ -299,5 +300,6 @@ async def test_fires_hass_event(button):
             "address": 1,
             "address_type": "Short",
             "instance_number": 1,
+            "unique_id": "test_23_button_events",
         },
     ) in button.hass.bus.events


### PR DESCRIPTION
## Summary
- Add integration `unique_id` to button event payloads
- Document event `unique_id` for differentiating buses
- Update tests for new event field

## Testing
- `pre-commit run --files custom_components/foxtron_dali/event.py tests/test_event.py README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b03a087134832393c6cebf007df2da